### PR TITLE
feat: dropdown styles

### DIFF
--- a/src/components/pages/Theme/Theme.css
+++ b/src/components/pages/Theme/Theme.css
@@ -6,3 +6,12 @@
   display: flex;
   gap: var(--spacing-1);
 }
+
+.dropdownBox {
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdownBox .dropdown {
+  margin: 5px 0;
+}

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -20,7 +20,6 @@ import './Theme.css';
 
 export const Theme = () => {
   // state
-  const [dropdownValue, setDropdownValue] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [isCheckboxChecked, setIsCheckboxChecked] = useState(false);
 
@@ -67,11 +66,6 @@ export const Theme = () => {
 
   const handleCheckboxOnChange = () => {
     setIsCheckboxChecked(!isCheckboxChecked);
-  };
-
-  const handleDropdownChange = (e, data) => {
-    alert(data.value);
-    setDropdownValue(data.value);
   };
 
   const panes = [
@@ -149,15 +143,25 @@ export const Theme = () => {
           <Header as='h2' dividing>
             Dropdown
           </Header>
-
-          <Dropdown
-            className='dropdownMenu'
-            onChange={handleDropdownChange}
-            options={dropdownOptions}
-            placeholder='Select'
-            selection
-            value={dropdownValue}
-          />
+          <div className='dropdownBox'>
+            <Dropdown
+              options={dropdownOptions}
+              placeholder='Select'
+              selection
+            />
+            <Dropdown
+              error
+              options={dropdownOptions}
+              placeholder='Select'
+              selection
+            />
+            <Dropdown
+              disabled
+              options={dropdownOptions}
+              placeholder='Select'
+              selection
+            />
+          </div>
         </Segment>
       </div>
 

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -38,21 +38,11 @@
   border-color: var(--primary-pms-362-900);
 }
 
-/** Error **/
-.ui.selection.dropdown.error {
-  border: 2px solid var(--alert-error-900);
-  background-color: var(--shade-white);
-}
-
-/** Error and Hover **/
-.ui.selection.dropdown.error:hover {
-  border-color: var(--alert-error-900);
-}
-
 /** Icon **/
 .ui.selection.dropdown > .dropdown.icon {
   top: 50%;
-  right: calc(var(--spacing-1) * 1.5);
+  margin: 0;
+  padding: 0;
   line-height: 0;
   color: var(--neutral-900);
   opacity: 1;
@@ -64,7 +54,16 @@
   border: none;
 }
 
-/** Options Menu and Error **/
+/** Error **/
+.ui.selection.dropdown.error {
+  border: 2px solid var(--alert-error-900);
+  background-color: var(--shade-white);
+}
+
+.ui.selection.dropdown.error:hover {
+  border-color: var(--alert-error-900);
+}
+
 .ui.dropdown.selection.error .menu.transition .item {
   color: var(--shade-black);
 }
@@ -75,4 +74,8 @@
 
 .ui.dropdown.selection.error .menu.transition .item.selected {
   background-color: rgba(0, 0, 0, 0.03);
+}
+
+.ui.selection.dropdown.error > .dropdown.icon {
+  color: var(--alert-error-900);
 }

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -1,1 +1,77 @@
 /* dropdown */
+
+.ui.selection.dropdown {
+  border-radius: 4px;
+  border: 1px solid var(--neutral-900);
+  padding: var(--spacing-1) var(--spacing-4) var(--spacing-1) var(--spacing-2);
+  min-width: 0;
+  min-height: 0;
+}
+
+.ui.selection.dropdown .divider.text {
+  color: var(--shade-black);
+  line-height: 1.5rem;
+}
+
+.ui.selection.dropdown .divider.default.text {
+  color: var(--neutral-900);
+}
+
+/** Focus **/
+.ui.selection.dropdown:not(.error):focus {
+  border-color: var(--primary-pms-362_900);
+}
+
+/** Focus and Hover **/
+.ui.selection.dropdown:not(.error):focus:hover {
+  border-color: var(--primary-pms-362_800);
+}
+
+/** Hover **/
+.ui.selection.dropdown:not(.error):hover {
+  border-color: var(--primary-pms-362_800);
+}
+
+/** Active **/
+.ui.active.visible.selection.dropdown:not(.error) {
+  border-color: var(--primary-pms-362_900);
+}
+
+/** Error **/
+.ui.selection.dropdown.error {
+  border: 2px solid var(--alert-error-900);
+  background-color: var(--shade-white);
+}
+
+/** Error and Hover **/
+.ui.selection.dropdown.error:hover {
+  border-color: var(--alert-error-900);
+}
+
+/** Icon **/
+.ui.selection.dropdown > .dropdown.icon {
+  top: 50%;
+  right: calc(var(--spacing-1) * 1.5);
+  line-height: 0;
+  color: var(--neutral-900);
+  opacity: 1;
+}
+
+/** Options Menu **/
+.ui.dropdown.selection .menu.transition {
+  border-radius: 0 0 4px 4px;
+  border: none;
+}
+
+/** Options Menu and Error **/
+.ui.dropdown.selection.error .menu.transition .item {
+  color: var(--shade-black);
+}
+
+.ui.dropdown.selection.error .menu.transition .item:hover {
+  background-color: #f2f2f2;
+}
+
+.ui.dropdown.selection.error .menu.transition .item.selected {
+  background-color: rgba(0, 0, 0, 0.03);
+}

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -20,22 +20,22 @@
 
 /** Focus **/
 .ui.selection.dropdown:not(.error):focus {
-  border-color: var(--primary-pms-362_900);
+  border-color: var(--primary-pms-362-900);
 }
 
 /** Focus and Hover **/
 .ui.selection.dropdown:not(.error):focus:hover {
-  border-color: var(--primary-pms-362_800);
+  border-color: var(--primary-pms-362-800);
 }
 
 /** Hover **/
 .ui.selection.dropdown:not(.error):hover {
-  border-color: var(--primary-pms-362_800);
+  border-color: var(--primary-pms-362-800);
 }
 
 /** Active **/
 .ui.active.visible.selection.dropdown:not(.error) {
-  border-color: var(--primary-pms-362_900);
+  border-color: var(--primary-pms-362-900);
 }
 
 /** Error **/

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -56,7 +56,7 @@
 
 /** Error **/
 .ui.selection.dropdown.error {
-  border: 2px solid var(--alert-error-900);
+  border: 1px solid var(--alert-error-900);
   background-color: var(--shade-white);
 }
 

--- a/src/styles/dropdown.css
+++ b/src/styles/dropdown.css
@@ -6,6 +6,7 @@
   padding: var(--spacing-1) var(--spacing-4) var(--spacing-1) var(--spacing-2);
   min-width: 0;
   min-height: 0;
+  font-family: var(--gotham);
 }
 
 .ui.selection.dropdown .divider.text {

--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -20,7 +20,7 @@
 
 /* Success */
 .ui.form .field.success > label {
-  color: var(--primary-pms-362_900);
+  color: var(--primary-pms-362-900);
 }
 
 /* Disabled */

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -8,7 +8,7 @@
 }
 
 .ui.input > input:focus {
-  border-color: var(--primary-pms-362_900);
+  border-color: var(--primary-pms-362-900);
 }
 
 .ui.input > input::placeholder {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -6,19 +6,19 @@
   --neutral-900: #808080;
 
   --primary-pms-539-600: #bfcad0;
-  --primary-pms-539_700: #8095a2;
-  --primary-pms-539_800: #406073;
-  --primary-pms-539_900: #002b45;
+  --primary-pms-539-700: #8095a2;
+  --primary-pms-539-800: #406073;
+  --primary-pms-539-900: #002b45;
 
   --primary-process-blue-600: #bfe0f2;
   --primary-process-blue-700: #80c2e4;
   --primary-process-blue-800: #40a3d7;
   --primary-process-blue-900: #0085ca;
 
-  --primary-pms-298_600: #d5ecf7;
-  --primary-pms-298_700: #abdaef;
-  --primary-pms-298_800: #81c7e8;
-  --primary-pms-298_900: #57b5e0;
+  --primary-pms-298-600: #d5ecf7;
+  --primary-pms-298-700: #abdaef;
+  --primary-pms-298-800: #81c7e8;
+  --primary-pms-298-900: #57b5e0;
 
   --secondary-pms-7462-600: #c2d6e3;
   --secondary-pms-7462-700: #86adc8;
@@ -30,10 +30,10 @@
   --secondary-pms-7457-300: #e0eaec;
   --secondary-pms-7457-400: #d6e3e6;
 
-  --primary-pms-362_600: #cbe0cf;
-  --primary-pms-362_700: #96c29f;
-  --primary-pms-362_800: #62a370;
-  --primary-pms-362_900: #2e8540;
+  --primary-pms-362-600: #cbe0cf;
+  --primary-pms-362-700: #96c29f;
+  --primary-pms-362-800: #62a370;
+  --primary-pms-362-900: #2e8540;
 
   --tertiary-cool-grey-700: #b5b0ad;
   --tertiary-cool-grey-900: #666366;


### PR DESCRIPTION
https://dev.azure.com/EY-GA/Global%20Atlantic%20DevOps/_boards/board/t/Global%20Atlantic%20Component%20Library%20Team/Stories/?workitem=23125

# Description

 - Added styles for Semantic UI `Dropdown`
 - Added variants `error` and `disabled` to the `Theme.tsx` file.

# Screenshot

![image](https://github.com/abby-moffitt/GA-Semantic/assets/101662434/95ab9b69-efda-4a02-81d6-d79b1e976bc5)

# Notes

In the `dropdown.css` file between the lines <b>71</b> and <b>77</b>, the colours used are the ones native to Semantic UI for the `default` variant. The `error` variant's colours are shades of `red`. But since we didn't have that implemented in our original design I decided to rely on the native colours for the `default` variant.

