### PR TITLE
feat: label styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Below are the Semantic UI components that have custom styles applied to them:
     <td>High</td>
   </tr>
   <tr>
+    <td><a href="https://react.semantic-ui.com/elements/label/" target="_blank">Label</a></td>
+    <td>Element</td>
+    <td>label.css</td>
+    <td>Medium</td>
+    <td>Medium</td>
+    <td>Low</td>
+  </tr>
+  <tr>
     <td><a href="https://react.semantic-ui.com/elements/segment/" target="_blank">Segment</a></td>
     <td>Element</td>
     <td>segment.css</td>

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -13,6 +13,7 @@ import {
   Tab,
   TextArea,
   Select,
+  Label,
 } from 'semantic-ui-react';
 
 // styles
@@ -258,6 +259,42 @@ export const Theme = () => {
             Tab
           </Header>
           <Tab panes={panes} />
+        </Segment>
+      </div>
+
+      <div className='section'>
+        <Segment padded>
+          <Header as='h2' dividing>
+            Chip
+          </Header>
+          <div className='row'>
+            <Label as='a' color='green'>
+              Filled Green
+              <Icon name='delete' />
+            </Label>
+            <Label as='a' color='blue'>
+              Filled Blue
+              <Icon name='delete' />
+            </Label>
+            <Label as='a' color='grey'>
+              Filled Grey
+              <Icon name='delete' />
+            </Label>
+          </div>
+          <div className='row'>
+            <Label as='a' basic color='green'>
+              Outlined Green
+              <Icon name='delete' />
+            </Label>
+            <Label as='a' basic color='blue'>
+              Outlined Blue
+              <Icon name='delete' />
+            </Label>
+            <Label as='a' basic color='grey'>
+              Outlined Grey
+              <Icon name='delete' />
+            </Label>
+          </div>
         </Segment>
       </div>
 

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -185,32 +185,10 @@ export const Theme = () => {
           </div>
         </Segment>
       </div>
-
       <div className='section'>
         <Segment>
           <Header as='h2' dividing>
-            Input
-          </Header>
-
-          <Input
-            value={inputValue}
-            onChange={handleInputChange}
-            placeholder='Text input'
-            icon={
-              inputValue.length === 0 ? (
-                ''
-              ) : (
-                <Icon name='times circle outline' onClick={handleClear} link />
-              )
-            }
-          />
-        </Segment>
-      </div>
-
-      <div className='section'>
-        <Segment>
-          <Header as='h2' dividing>
-            Label
+            Form
           </Header>
 
           <Form>
@@ -254,47 +232,77 @@ export const Theme = () => {
       </div>
 
       <div className='section'>
+        <Segment>
+          <Header as='h2' dividing>
+            Input
+          </Header>
+
+          <Input
+            value={inputValue}
+            onChange={handleInputChange}
+            placeholder='Text input'
+            icon={
+              inputValue.length === 0 ? (
+                ''
+              ) : (
+                <Icon name='times circle outline' onClick={handleClear} link />
+              )
+            }
+          />
+        </Segment>
+      </div>
+      <div className='section'>
+        <Segment padded>
+          <Header as='h2' dividing>
+            Label
+          </Header>
+          <Header size='small' dividing>
+            Default
+          </Header>
+          <div className='row'>
+            <Label color='green'>Filled Green</Label>
+            <Label color='blue'>Filled Blue</Label>
+            <Label color='grey'>Filled Grey</Label>
+          </div>
+          <Header size='small' dividing>
+            Outlined
+          </Header>
+          <div className='row'>
+            <Label basic color='green'>
+              Outlined Green
+            </Label>
+            <Label basic color='blue'>
+              Outlined Blue
+            </Label>
+            <Label basic color='grey'>
+              Outlined Grey
+            </Label>
+          </div>
+          <Header size='small' dividing>
+            Interactive
+          </Header>
+          <div className='row'>
+            <Label basic as='button' color='green'>
+              Interactive
+              <Icon name='delete' />
+            </Label>
+            <Label as='button' color='blue'>
+              Interactive
+              <Icon name='delete' />
+            </Label>
+            <Label as='button' color='grey'>
+              Interactive
+              <Icon name='delete' />
+            </Label>
+          </div>
+        </Segment>
+      </div>
+      <div className='section'>
         <Segment padded>
           <Header as='h2' dividing>
             Tab
           </Header>
           <Tab panes={panes} />
-        </Segment>
-      </div>
-
-      <div className='section'>
-        <Segment padded>
-          <Header as='h2' dividing>
-            Chip
-          </Header>
-          <div className='row'>
-            <Label as='a' color='green'>
-              Filled Green
-              <Icon name='delete' />
-            </Label>
-            <Label as='a' color='blue'>
-              Filled Blue
-              <Icon name='delete' />
-            </Label>
-            <Label as='a' color='grey'>
-              Filled Grey
-              <Icon name='delete' />
-            </Label>
-          </div>
-          <div className='row'>
-            <Label as='a' basic color='green'>
-              Outlined Green
-              <Icon name='delete' />
-            </Label>
-            <Label as='a' basic color='blue'>
-              Outlined Blue
-              <Icon name='delete' />
-            </Label>
-            <Label as='a' basic color='grey'>
-              Outlined Grey
-              <Icon name='delete' />
-            </Label>
-          </div>
         </Segment>
       </div>
 

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -188,7 +188,7 @@ export const Theme = () => {
       <div className='section'>
         <Segment>
           <Header as='h2' dividing>
-            Form
+            Form Label
           </Header>
 
           <Form>

--- a/src/ga.css
+++ b/src/ga.css
@@ -6,5 +6,6 @@
 @import 'styles/form.css';
 @import 'styles/header.css';
 @import 'styles/input.css';
+@import 'styles/label.css';
 @import 'styles/menu.css';
 @import 'styles/segment.css';

--- a/src/styles/label.css
+++ b/src/styles/label.css
@@ -1,0 +1,90 @@
+/* label */
+
+.ui.label {
+  font-family: var(--gotham);
+  font-size: 1rem;
+  font-weight: 400;
+  padding: var(--spacing-1) 10px;
+  border-radius: 6px;
+}
+
+/* green */
+
+.ui.label.green {
+  background-color: var(--primary-pms-362-900) !important;
+  color: var(--shade-white) !important;
+}
+
+a.ui.label.green:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--primary-pms-362-600) !important;
+}
+
+/** grey **/
+
+.ui.label.grey {
+  background-color: var(--secondary-pms-7457-400) !important;
+  color: var(--shade-black) !important;
+}
+
+a.ui.label.grey:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--primary-pms-298-700) !important;
+}
+
+/** blue **/
+
+.ui.label.blue {
+  background-color: var(--secondary-pms-7462-800) !important;
+  color: var(--shade-white) !important;
+}
+
+a.ui.label.blue:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--secondary-pms-7457-400) !important;
+}
+
+/** basic - outlined **/
+
+.ui.label.basic {
+  border-width: 2px;
+}
+
+/** basic green **/
+
+.ui.label.basic.green {
+  color: var(--primary-pms-362-900) !important;
+  border-color: var(--primary-pms-362-900) !important;
+}
+
+a.ui.label.basic.green:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--primary-pms-362-600) !important;
+  border-color: var(--primary-pms-362-900) !important;
+}
+
+/** basic grey **/
+
+.ui.label.basic.grey {
+  color: var(--secondary-pms-7457-400) !important;
+  border-color: var(--secondary-pms-7457-400) !important;
+}
+
+a.ui.label.basic.grey:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--primary-pms-298-700) !important;
+  border-color: var(--secondary-pms-7457-400) !important;
+}
+
+/** basic blue **/
+
+.ui.label.basic.blue {
+  color: var(--secondary-pms-7462-800) !important;
+  border-color: var(--secondary-pms-7462-800) !important;
+}
+
+a.ui.label.basic.blue:hover {
+  color: var(--shade-black) !important;
+  background-color: var(--secondary-pms-7457-400) !important;
+  border-color: var(--secondary-pms-7462-800) !important;
+}

--- a/src/styles/label.css
+++ b/src/styles/label.css
@@ -6,6 +6,12 @@
   font-weight: 400;
   padding: var(--spacing-1) 10px;
   border-radius: 6px;
+  transition: var(--transition-hover);
+}
+
+a.ui.label,
+button.ui.label {
+  cursor: pointer;
 }
 
 /* green */
@@ -15,7 +21,8 @@
   color: var(--shade-white) !important;
 }
 
-a.ui.label.green:hover {
+a.ui.label.green:hover,
+button.ui.label.green:hover {
   color: var(--shade-black) !important;
   background-color: var(--primary-pms-362-600) !important;
 }
@@ -27,7 +34,8 @@ a.ui.label.green:hover {
   color: var(--shade-black) !important;
 }
 
-a.ui.label.grey:hover {
+a.ui.label.grey:hover,
+button.ui.label.grey:hover {
   color: var(--shade-black) !important;
   background-color: var(--primary-pms-298-700) !important;
 }
@@ -39,7 +47,8 @@ a.ui.label.grey:hover {
   color: var(--shade-white) !important;
 }
 
-a.ui.label.blue:hover {
+a.ui.label.blue:hover,
+button.ui.label.blue:hover {
   color: var(--shade-black) !important;
   background-color: var(--secondary-pms-7457-400) !important;
 }
@@ -57,7 +66,8 @@ a.ui.label.blue:hover {
   border-color: var(--primary-pms-362-900) !important;
 }
 
-a.ui.label.basic.green:hover {
+a.ui.label.basic.green:hover,
+button.ui.label.basic.green:hover {
   color: var(--shade-black) !important;
   background-color: var(--primary-pms-362-600) !important;
   border-color: var(--primary-pms-362-900) !important;
@@ -70,7 +80,8 @@ a.ui.label.basic.green:hover {
   border-color: var(--secondary-pms-7457-400) !important;
 }
 
-a.ui.label.basic.grey:hover {
+a.ui.label.basic.grey:hover,
+button.ui.label.basic.grey:hover {
   color: var(--shade-black) !important;
   background-color: var(--primary-pms-298-700) !important;
   border-color: var(--secondary-pms-7457-400) !important;
@@ -83,7 +94,8 @@ a.ui.label.basic.grey:hover {
   border-color: var(--secondary-pms-7462-800) !important;
 }
 
-a.ui.label.basic.blue:hover {
+a.ui.label.basic.blue:hover,
+button.ui.label.basic.blue:hover {
   color: var(--shade-black) !important;
   background-color: var(--secondary-pms-7457-400) !important;
   border-color: var(--secondary-pms-7462-800) !important;


### PR DESCRIPTION
https://dev.azure.com/EY-GA/Global%20Atlantic%20DevOps/_boards/board/t/Global%20Atlantic%20Component%20Library%20Team/Stories/?workitem=23513

# Description

Styles for the Semantic UI `Label` component.

# Screenshots

![image](https://github.com/abby-moffitt/GA-Semantic/assets/101662434/4ce8c3c2-9f31-4307-91b7-d59ce1107c07)

# Notes

Few things I wanted to highlight:

1. The styles that come from Semantic UI, already have the `!important` tag in them: 

      ![image](https://github.com/abby-moffitt/GA-Semantic/assets/101662434/1343af2b-409c-461d-abcf-6523c3e78b27)

      Hence, I needed to make use of them in order to have our styles reflected.


2. Semantic UI has some styles for the `Label` when it is an `a` tag and it's hovered. I could not find styles in the documentation when it comes to the `outlined` variant. So I followed what we had implemented in the first version of the library. 

3. I did not style the `icon` that's used inside of the `tag`. My thought was that the portal is not using the `Icon` component from Semantic UI, since Semantic doesn't have all the icons that have been used in the designs. So the styling of the `icon` should be done separately. 


Please let me know if any of these assumptions were not accurate and if anything needs to be changed! 
