### PR TITLE
fix: input styles for form fields

### DIFF
--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -285,7 +285,7 @@ export const Theme = () => {
           <Form>
             <Form.Field required>
               <label htmlFor='input-default'>Label</label>
-              <Input id='input-default' placeholder='Input' />
+              <Input id='input-default' placeholder='Input...' />
             </Form.Field>
 
             <Header size='small' dividing>
@@ -293,17 +293,17 @@ export const Theme = () => {
             </Header>
             <Form.Field className='error'>
               <label htmlFor='input-error'>Error</label>
-              <Input id='input-error' placeholder='Input' />
+              <Input id='input-error' placeholder='Input...' />
             </Form.Field>
 
             <Form.Field className='success'>
               <label htmlFor='input-success'>Success</label>
-              <Input id='input-success' placeholder='Input' />
+              <Input id='input-success' placeholder='Input...' />
             </Form.Field>
 
             <Form.Field className='disabled'>
               <label htmlFor='input-disabled'>Disabled</label>
-              <Input id='input-disabled' placeholder='Input' />
+              <Input id='input-disabled' placeholder='Input...' />
             </Form.Field>
           </Form>
         </Segment>
@@ -319,7 +319,7 @@ export const Theme = () => {
             <Input
               value={inputValue}
               onChange={handleInputChange}
-              placeholder='Text input'
+              placeholder='Text input...'
               icon={
                 inputValue.length === 0 ? (
                   ''
@@ -333,6 +333,11 @@ export const Theme = () => {
               }
             />
           </div>
+
+          <Header size='small' dividing>
+            Error
+          </Header>
+          <Input error placeholder='Validation error...' />
 
           <Header size='small' dividing>
             Types
@@ -526,11 +531,20 @@ export const Theme = () => {
           </Header>
 
           <Form>
-            <Form.Field
-              control={TextArea}
-              label='Textarea'
-              placeholder='Type your text here...'
-            />
+            <div className='column'>
+              <Form.Field
+                control={TextArea}
+                label='Textarea'
+                placeholder='Type your text here...'
+              />
+
+              <Form.Field
+                control={TextArea}
+                error
+                label='Error'
+                placeholder='Type your text here...'
+              />
+            </div>
           </Form>
         </Segment>
       </div>

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -340,6 +340,11 @@ export const Theme = () => {
           <Input error placeholder='Validation error...' />
 
           <Header size='small' dividing>
+            Disabled
+          </Header>
+          <Input disabled placeholder='Disabled input...' />
+
+          <Header size='small' dividing>
             Types
           </Header>
           <Form>
@@ -352,6 +357,7 @@ export const Theme = () => {
                   label={type}
                   type={type}
                   placeholder={`${type} input...`}
+                  disabled
                 />
               ))}
             </div>
@@ -535,14 +541,21 @@ export const Theme = () => {
               <Form.Field
                 control={TextArea}
                 label='Textarea'
-                placeholder='Type your text here...'
+                placeholder='Textarea example...'
               />
 
               <Form.Field
                 control={TextArea}
                 error
                 label='Error'
-                placeholder='Type your text here...'
+                placeholder='Textarea example...'
+              />
+
+              <Form.Field
+                control={TextArea}
+                disabled
+                label='Disabled'
+                placeholder='Textarea example...'
               />
             </div>
           </Form>

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -346,6 +346,7 @@ export const Theme = () => {
                   key={`input-type-${index}`}
                   label={type}
                   type={type}
+                  placeholder={`${type} input...`}
                 />
               ))}
             </div>

--- a/src/components/pages/Theme/Theme.jsx
+++ b/src/components/pages/Theme/Theme.jsx
@@ -111,6 +111,7 @@ export const Theme = () => {
 
   const contentText =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.';
+  const placeholderText = 'Enter your value here...';
 
   const inputTypes = [
     'color',
@@ -270,7 +271,7 @@ export const Theme = () => {
                 { key: 'option1', text: 'Option 1', value: 'option1' },
                 { key: 'option2', text: 'Option 2', value: 'option2' },
               ]}
-              placeholder='Select options'
+              placeholder='Select'
             />
           </Form>
         </Segment>
@@ -285,7 +286,7 @@ export const Theme = () => {
           <Form>
             <Form.Field required>
               <label htmlFor='input-default'>Label</label>
-              <Input id='input-default' placeholder='Input...' />
+              <Input id='input-default' placeholder={placeholderText} />
             </Form.Field>
 
             <Header size='small' dividing>
@@ -293,17 +294,17 @@ export const Theme = () => {
             </Header>
             <Form.Field className='error'>
               <label htmlFor='input-error'>Error</label>
-              <Input id='input-error' placeholder='Input...' />
+              <Input id='input-error' placeholder={placeholderText} />
             </Form.Field>
 
             <Form.Field className='success'>
               <label htmlFor='input-success'>Success</label>
-              <Input id='input-success' placeholder='Input...' />
+              <Input id='input-success' placeholder={placeholderText} />
             </Form.Field>
 
             <Form.Field className='disabled'>
               <label htmlFor='input-disabled'>Disabled</label>
-              <Input id='input-disabled' placeholder='Input...' />
+              <Input id='input-disabled' placeholder={placeholderText} />
             </Form.Field>
           </Form>
         </Segment>
@@ -319,7 +320,7 @@ export const Theme = () => {
             <Input
               value={inputValue}
               onChange={handleInputChange}
-              placeholder='Text input...'
+              placeholder={placeholderText}
               icon={
                 inputValue.length === 0 ? (
                   ''
@@ -337,12 +338,12 @@ export const Theme = () => {
           <Header size='small' dividing>
             Error
           </Header>
-          <Input error placeholder='Validation error...' />
+          <Input error placeholder={placeholderText} />
 
           <Header size='small' dividing>
             Disabled
           </Header>
-          <Input disabled placeholder='Disabled input...' />
+          <Input disabled placeholder={placeholderText} />
 
           <Header size='small' dividing>
             Types
@@ -356,8 +357,7 @@ export const Theme = () => {
                   key={`input-type-${index}`}
                   label={type}
                   type={type}
-                  placeholder={`${type} input...`}
-                  disabled
+                  placeholder={placeholderText}
                 />
               ))}
             </div>
@@ -541,21 +541,21 @@ export const Theme = () => {
               <Form.Field
                 control={TextArea}
                 label='Textarea'
-                placeholder='Textarea example...'
+                placeholder={placeholderText}
               />
 
               <Form.Field
                 control={TextArea}
                 error
                 label='Error'
-                placeholder='Textarea example...'
+                placeholder={placeholderText}
               />
 
               <Form.Field
                 control={TextArea}
                 disabled
                 label='Disabled'
-                placeholder='Textarea example...'
+                placeholder={placeholderText}
               />
             </div>
           </Form>

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -131,6 +131,7 @@
 .ui.form .field.disabled textarea {
   color: var(--neutral-700);
   border: 1px solid var(--neutral-700);
+  opacity: 1;
 }
 
 .ui.input.disabled > input::placeholder,

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -17,6 +17,7 @@
   border-radius: var(--border-radius-2);
   border: 1px solid var(--neutral-900);
   box-shadow: none;
+  color: var(--shade-black);
   font-family: var(--gotham);
   font-size: var(--font-size);
   line-height: var(--line-height);
@@ -57,14 +58,57 @@
   font-weight: 400;
 }
 
-.ui.input.error > input {
+/* error */
+
+.ui.input.error > input,
+.ui.form .field.error input[type='color'],
+.ui.form .field.error input[type='date'],
+.ui.form .field.error input[type='datetime-local'],
+.ui.form .field.error input[type='email'],
+.ui.form .field.error input[type='file'],
+.ui.form .field.error input[type='number'],
+.ui.form .field.error input[type='password'],
+.ui.form .field.error input[type='search'],
+.ui.form .field.error input[type='tel'],
+.ui.form .field.error input[type='text'],
+.ui.form .field.error input[type='time'],
+.ui.form .field.error input[type='url'],
+.ui.form .field.error textarea {
+  background: var(--shade-white);
   border: 2px solid var(--alert-error-900);
   color: var(--shade-black);
-  background-color: var(--shade-white);
+}
+
+.ui.form .field.error input[type='color']:focus,
+.ui.form .field.error input[type='date']:focus,
+.ui.form .field.error input[type='datetime-local']:focus,
+.ui.form .field.error input[type='email']:focus,
+.ui.form .field.error input[type='file']:focus,
+.ui.form .field.error input[type='number']:focus,
+.ui.form .field.error input[type='password']:focus,
+.ui.form .field.error input[type='search']:focus,
+.ui.form .field.error input[type='tel']:focus,
+.ui.form .field.error input[type='text']:focus,
+.ui.form .field.error input[type='time']:focus,
+.ui.form .field.error input[type='url']:focus,
+.ui.form .field.error textarea:focus {
+  background: var(--shade-white);
+  border: 2px solid var(--alert-error-900);
+  color: var(--shade-black);
 }
 
 .ui.input.error > input::placeholder,
-.ui.input.error > input:focus::placeholder {
+.ui.input.error > input:focus::placeholder,
+.ui.form .field.error input[type='email']:focus::placeholder,
+.ui.form .field.error input[type='file']:focus::placeholder,
+.ui.form .field.error input[type='number']:focus::placeholder,
+.ui.form .field.error input[type='password']:focus::placeholder,
+.ui.form .field.error input[type='search']:focus::placeholder,
+.ui.form .field.error input[type='tel']:focus::placeholder,
+.ui.form .field.error input[type='text']:focus::placeholder,
+.ui.form .field.error input[type='url']:focus::placeholder,
+.ui.form .field.error textarea::placeholder,
+.ui.form .field.error textarea:focus::placeholder {
   color: var(--neutral-900);
   font-weight: 400;
 }

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -24,6 +24,10 @@
   padding: var(--spacing-1) var(--spacing-4) var(--spacing-1) var(--spacing-2);
 }
 
+.ui.form textarea {
+  padding: var(--spacing-2);
+}
+
 /* focus */
 
 .ui.input > input:focus,

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -1,11 +1,29 @@
-.ui.input > input {
-  padding: var(--spacing-1) var(--spacing-4) var(--spacing-1) var(--spacing-2);
-  line-height: var(--line-height);
+/* input */
+
+.ui.input > input,
+.ui.form input[type='date'],
+.ui.form input[type='datetime-local'],
+.ui.form input[type='email'],
+.ui.form input[type='file'],
+.ui.form input[type='number'],
+.ui.form input[type='password'],
+.ui.form input[type='search'],
+.ui.form input[type='tel'],
+.ui.form input[type='text'],
+.ui.form input[type='time'],
+.ui.form input[type='url'],
+.ui.form textarea {
+  background: var(--shade-white);
   border-radius: var(--border-radius-2);
-  background-color: var(--shade-white);
   border: 1px solid var(--neutral-900);
+  box-shadow: none;
+  font-family: var(--gotham);
   font-size: var(--font-size);
+  line-height: var(--line-height);
+  padding: var(--spacing-1) var(--spacing-4) var(--spacing-1) var(--spacing-2);
 }
+
+/* focus */
 
 .ui.input > input:focus,
 .ui.form input[type='color']:focus,
@@ -24,7 +42,17 @@
   border-color: var(--primary-pms-362-900);
 }
 
-.ui.input > input::placeholder {
+/* placeholder */
+
+.ui.input > input::placeholder,
+.ui.form input[type='email']::placeholder,
+.ui.form input[type='number']::placeholder,
+.ui.form input[type='password']::placeholder,
+.ui.form input[type='search']::placeholder,
+.ui.form input[type='tel']::placeholder,
+.ui.form input[type='text']::placeholder,
+.ui.form input[type='url']::placeholder,
+.ui.form textarea::placeholder {
   color: var(--neutral-900);
   font-weight: 400;
 }

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -113,13 +113,44 @@
   font-weight: 400;
 }
 
-.ui.input.disabled > input {
+/* disabled */
+
+.ui.input.disabled > input,
+.ui.form .field.disabled input[type='color'],
+.ui.form .field.disabled input[type='date'],
+.ui.form .field.disabled input[type='datetime-local'],
+.ui.form .field.disabled input[type='email'],
+.ui.form .field.disabled input[type='file'],
+.ui.form .field.disabled input[type='number'],
+.ui.form .field.disabled input[type='password'],
+.ui.form .field.disabled input[type='search'],
+.ui.form .field.disabled input[type='tel'],
+.ui.form .field.disabled input[type='text'],
+.ui.form .field.disabled input[type='time'],
+.ui.form .field.disabled input[type='url'],
+.ui.form .field.disabled textarea {
+  color: var(--neutral-700);
   border: 1px solid var(--neutral-700);
 }
 
-.ui.input.disabled > input::placeholder {
-  color: var(--neutral-700);
+.ui.input.disabled > input::placeholder,
+.ui.form .field.disabled input[type='color']::placeholder,
+.ui.form .field.disabled input[type='date']::placeholder,
+.ui.form .field.disabled input[type='datetime-local']::placeholder,
+.ui.form .field.disabled input[type='email']::placeholder,
+.ui.form .field.disabled input[type='file']::placeholder,
+.ui.form .field.disabled input[type='number']::placeholder,
+.ui.form .field.disabled input[type='password']::placeholder,
+.ui.form .field.disabled input[type='search']::placeholder,
+.ui.form .field.disabled input[type='tel']::placeholder,
+.ui.form .field.disabled input[type='text']::placeholder,
+.ui.form .field.disabled input[type='time']::placeholder,
+.ui.form .field.disabled input[type='url']::placeholder,
+.ui.form .field.disabled textarea::placeholder {
+  color: var(--neutral-500);
 }
+
+/* icon */
 
 .ui.input .icon {
   color: var(--tertiary-cool-grey-900);


### PR DESCRIPTION
[USER STORY 23983](https://dev.azure.com/EY-GA/Global%20Atlantic%20DevOps/_workitems/edit/23983)

## Description

- Input styles are now aligned with the form fields;
- Added _error_ styles for the form fields;
- Added _disabled_  styles for the form fields;
- Added placeholder styles for the form fields;

## Motivation

To make sure that both Semantic UI `Input` and `Form.Field` inputs have the same styles;

## Screenshots

<img width="350" alt="Screenshot 2023-06-14 at 3 21 25 PM" src="https://github.com/abby-moffitt/GA-Semantic/assets/64768811/9ecf6144-9b6b-4a3b-a12f-4f0e31a7cfb3">


## Testing

Run the theme --> validate all inputs;
